### PR TITLE
include flag name when erroring on env default

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -316,6 +316,12 @@ func (p *Parser) ParseArgs(args []string) ([]string, error) {
 
 			err := option.clearDefault()
 			if err != nil {
+				if _, ok := err.(*Error); !ok {
+					err = newErrorf(ErrMarshal, "invalid argument for flag `%s' (expected %s): %s",
+						option,
+						option.value.Type(),
+						err.Error())
+				}
 				s.err = err
 			}
 		})

--- a/parser_test.go
+++ b/parser_test.go
@@ -358,7 +358,7 @@ func TestEnvDefaults(t *testing.T) {
 		for envKey, envValue := range test.env {
 			os.Setenv(envKey, envValue)
 		}
-		_, err := ParseArgs(&opts, test.args)
+		_, err := NewParser(&opts, None).ParseArgs(test.args)
 		if test.expectedErr != "" {
 			if err == nil {
 				t.Errorf("%s:\nExpected error containing substring %q", test.msg, test.expectedErr)


### PR DESCRIPTION
This addresses https://github.com/concourse/concourse/pull/5429#discussion_r414572750.

This is absolutely necessary -- if you are passing many flags via environment variables, it can be very mysterious to determine which one is invalid. Frankly, my discoveries [here](https://github.com/concourse/concourse/pull/5429#issuecomment-618576706) and [here](https://github.com/concourse/concourse/pull/5429#issuecomment-619005709) were very lucky.

Also I quieted the parser test. By adding a test that had a parse error, we were actually clogging the output stream of the test runner.